### PR TITLE
Auto-run database migrations on container startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,9 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-    command: uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    command: >
+      sh -c "alembic upgrade head &&
+             uvicorn app.main:app --reload --host 0.0.0.0 --port 8000"
 
   # Frontend runs locally: cd frontend && npm run dev
   # Removed from Docker to avoid node_modules sync issues


### PR DESCRIPTION
## Summary
- Run `alembic upgrade head` before starting uvicorn to ensure migrations are applied automatically

## Test plan
- [x] Verified migrations run on startup (visible in logs)
- [x] Verified backend starts successfully after migrations
- [x] Verified health endpoint returns healthy status