### PR TITLE
feat(arena): IBS entry filter blocks overbought entries

### DIFF
--- a/backend/app/api/v1/arena.py
+++ b/backend/app/api/v1/arena.py
@@ -105,6 +105,7 @@ def _build_simulation_response(simulation: ArenaSimulation) -> SimulationRespons
     risk_per_trade_pct = agent_config.get("risk_per_trade_pct")
     win_streak_bonus_pct = agent_config.get("win_streak_bonus_pct")
     max_risk_pct = agent_config.get("max_risk_pct")
+    ibs_max_threshold = agent_config.get("ibs_max_threshold")
 
     return SimulationResponse(
         id=simulation.id,
@@ -136,6 +137,7 @@ def _build_simulation_response(simulation: ArenaSimulation) -> SimulationRespons
         risk_per_trade_pct=risk_per_trade_pct,
         win_streak_bonus_pct=win_streak_bonus_pct,
         max_risk_pct=max_risk_pct,
+        ibs_max_threshold=ibs_max_threshold,
         group_id=simulation.group_id,
         status=simulation.status,
         current_day=simulation.current_day,
@@ -294,6 +296,8 @@ async def create_simulation(
         "regime_bear_max_positions": request.regime_bear_max_positions,
         # Layer 9: Portfolio selector tuning
         "ma_sweet_spot_center": request.ma_sweet_spot_center,
+        # Layer 10: Entry filters
+        "ibs_max_threshold": request.ibs_max_threshold,
     }
     if request.agent_config_id is not None:
         agent_config["agent_config_id"] = request.agent_config_id
@@ -713,6 +717,8 @@ async def create_comparison(
         "risk_per_trade_pct": request.risk_per_trade_pct,
         "win_streak_bonus_pct": request.win_streak_bonus_pct,
         "max_risk_pct": request.max_risk_pct,
+        # Layer 10: Entry filters
+        "ibs_max_threshold": request.ibs_max_threshold,
     }
     if request.agent_config_id is not None:
         base_agent_config["agent_config_id"] = request.agent_config_id

--- a/backend/app/schemas/arena.py
+++ b/backend/app/schemas/arena.py
@@ -267,6 +267,18 @@ class CreateSimulationRequest(StrictBaseModel):
         ),
     )
 
+    # --- Layer 10: Entry Filters ---
+    ibs_max_threshold: float | None = Field(
+        default=None,
+        gt=0,
+        le=1,
+        description=(
+            "Internal Bar Strength (IBS) maximum threshold. IBS = (close-low)/(high-low). "
+            "BUY signals are filtered when IBS >= threshold (stock already near daily high). "
+            "None = disabled. Must be in (0, 1]."
+        ),
+    )
+
     # --- Layer 7: Market Regime Filter ---
     regime_filter: bool = Field(
         default=False,
@@ -494,6 +506,18 @@ class CreateComparisonRequest(StrictBaseModel):
         description="Maximum effective risk % per trade cap (sizing_mode='risk_based').",
     )
 
+    # --- Layer 10: Entry Filters ---
+    ibs_max_threshold: float | None = Field(
+        default=None,
+        gt=0,
+        le=1,
+        description=(
+            "Internal Bar Strength (IBS) maximum threshold. IBS = (close-low)/(high-low). "
+            "BUY signals are filtered when IBS >= threshold (stock already near daily high). "
+            "None = disabled. Must be in (0, 1]."
+        ),
+    )
+
     # Shared validators — same standalone functions as CreateSimulationRequest
     _normalize_symbols = field_validator("symbols", mode="before")(_normalize_symbols_value)
     _validate_symbols_count = field_validator("symbols")(_validate_symbols_count_value)
@@ -663,6 +687,7 @@ class SimulationResponse(StrictBaseModel):
     risk_per_trade_pct: float | None = None
     win_streak_bonus_pct: float | None = None
     max_risk_pct: float | None = None
+    ibs_max_threshold: float | None = None
     group_id: str | None = None
     status: str
     current_day: int

--- a/backend/app/services/arena/simulation_engine.py
+++ b/backend/app/services/arena/simulation_engine.py
@@ -399,7 +399,7 @@ class SimulationEngine:
         # Process each symbol
         decisions: dict[str, dict] = {}
         # Collect BUY signals for portfolio selection (processed after symbol loop)
-        buy_signals: list[tuple[str, AgentDecision]] = []
+        buy_signals: list[tuple[str, AgentDecision, PriceBar]] = []
 
         for symbol in simulation.symbols:
             # Get price history up to current date
@@ -713,9 +713,10 @@ class SimulationEngine:
                 "reasoning": decision.reasoning,
             }
 
-            # Collect BUY signals for portfolio selection (don't create PENDING yet)
+            # Collect BUY signals for portfolio selection (don't create PENDING yet).
+            # today_bar rides along so Layer 10 filters don't re-scan the price cache.
             if decision.action == "BUY" and not has_position:
-                buy_signals.append((symbol, decision))
+                buy_signals.append((symbol, decision, today_bar))
 
         # --- Layer 10: Entry Filters ---
         # Prune BUY signals by Internal Bar Strength before portfolio selection.
@@ -724,15 +725,16 @@ class SimulationEngine:
         # neutral IBS=0.5.
         ibs_max = simulation.agent_config.get("ibs_max_threshold")
         if ibs_max is not None:
-            filtered_buy_signals = []
-            for symbol, decision in buy_signals:
-                today_bar = self._get_cached_bar_for_date(simulation_id, symbol, current_date)
-                if today_bar and today_bar.high != today_bar.low:
-                    ibs = float((today_bar.close - today_bar.low) / (today_bar.high - today_bar.low))
+            filtered_buy_signals: list[tuple[str, AgentDecision, PriceBar]] = []
+            for symbol, decision, today_bar in buy_signals:
+                if today_bar.high != today_bar.low:
+                    ibs = float(
+                        (today_bar.close - today_bar.low) / (today_bar.high - today_bar.low)
+                    )
                 else:
                     ibs = 0.5
                 if ibs < ibs_max:
-                    filtered_buy_signals.append((symbol, decision))
+                    filtered_buy_signals.append((symbol, decision, today_bar))
                 else:
                     decisions[symbol]["ibs_filtered"] = True
                     decisions[symbol]["ibs_value"] = round(ibs, 4)
@@ -775,7 +777,7 @@ class SimulationEngine:
         # Build qualifying signals with sector and ATR data from caches
         qualifying: list[QualifyingSignal] = []
         sim_sector_map = self._sector_cache.get(simulation_id, {})
-        for symbol, decision in buy_signals:
+        for symbol, decision, _today_bar in buy_signals:
             qualifying.append(
                 QualifyingSignal(
                     symbol=symbol,
@@ -804,7 +806,7 @@ class SimulationEngine:
         selected_symbols = {s.symbol for s in selected}
 
         # Create PENDING positions for selected signals only
-        for symbol, decision in buy_signals:
+        for symbol, decision, _today_bar in buy_signals:
             is_selected = symbol in selected_symbols
             # Annotate decision for transparency in snapshots
             decisions[symbol]["portfolio_selected"] = is_selected

--- a/backend/app/services/arena/simulation_engine.py
+++ b/backend/app/services/arena/simulation_engine.py
@@ -717,6 +717,28 @@ class SimulationEngine:
             if decision.action == "BUY" and not has_position:
                 buy_signals.append((symbol, decision))
 
+        # --- Layer 10: Entry Filters ---
+        # Prune BUY signals by Internal Bar Strength before portfolio selection.
+        # IBS = (close - low) / (high - low); signals with IBS >= threshold are
+        # filtered out (stock already near daily high). Zero-range days use
+        # neutral IBS=0.5.
+        ibs_max = simulation.agent_config.get("ibs_max_threshold")
+        if ibs_max is not None:
+            filtered_buy_signals = []
+            for symbol, decision in buy_signals:
+                today_bar = self._get_cached_bar_for_date(simulation_id, symbol, current_date)
+                if today_bar and today_bar.high != today_bar.low:
+                    ibs = float((today_bar.close - today_bar.low) / (today_bar.high - today_bar.low))
+                else:
+                    ibs = 0.5
+                if ibs < ibs_max:
+                    filtered_buy_signals.append((symbol, decision))
+                else:
+                    decisions[symbol]["ibs_filtered"] = True
+                    decisions[symbol]["ibs_value"] = round(ibs, 4)
+                    decisions[symbol]["portfolio_selected"] = False
+            buy_signals = filtered_buy_signals
+
         # --- Portfolio Selection ---
         # Read strategy configuration from agent_config (defaults preserve original behavior)
         strategy_name = simulation.agent_config.get("portfolio_strategy", "none")

--- a/backend/tests/integration/test_arena_api.py
+++ b/backend/tests/integration/test_arena_api.py
@@ -418,3 +418,68 @@ async def test_get_simulation_calls_batch_prefetch_sectors_and_returns_backfille
         assert "NVDA" in symbols_arg
     finally:
         app.dependency_overrides.pop(get_data_service, None)
+
+
+# ---------------------------------------------------------------------------
+# IBS Entry Filter — Schema Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_with_ibs_max_threshold_accepted_and_returned(
+    async_client: AsyncClient,
+) -> None:
+    """POST with ibs_max_threshold=0.55 accepted; GET returns it in the response."""
+    payload = {
+        **VALID_SIMULATION_PAYLOAD,
+        "ibs_max_threshold": 0.55,
+    }
+    response = await async_client.post("/api/v1/arena/simulations", json=payload)
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["ibs_max_threshold"] == 0.55
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_ibs_max_threshold_zero_returns_422(
+    async_client: AsyncClient,
+) -> None:
+    """POST with ibs_max_threshold=0 rejected with 422 (gt=0 constraint)."""
+    payload = {
+        **VALID_SIMULATION_PAYLOAD,
+        "ibs_max_threshold": 0,
+    }
+    response = await async_client.post("/api/v1/arena/simulations", json=payload)
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_ibs_max_threshold_negative_returns_422(
+    async_client: AsyncClient,
+) -> None:
+    """POST with ibs_max_threshold=-0.01 rejected with 422 (gt=0 constraint)."""
+    payload = {
+        **VALID_SIMULATION_PAYLOAD,
+        "ibs_max_threshold": -0.01,
+    }
+    response = await async_client.post("/api/v1/arena/simulations", json=payload)
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_ibs_max_threshold_upper_bound_accepted(
+    async_client: AsyncClient,
+) -> None:
+    """POST with ibs_max_threshold=1.0 accepted (le=1, upper bound inclusive)."""
+    payload = {
+        **VALID_SIMULATION_PAYLOAD,
+        "ibs_max_threshold": 1.0,
+    }
+    response = await async_client.post("/api/v1/arena/simulations", json=payload)
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["ibs_max_threshold"] == 1.0

--- a/backend/tests/unit/api/v1/test_arena_comparison.py
+++ b/backend/tests/unit/api/v1/test_arena_comparison.py
@@ -214,6 +214,26 @@ class TestCreateComparison:
             assert sim["min_buy_score"] == 70
 
     @pytest.mark.asyncio
+    async def test_create_comparison_with_ibs_max_threshold_propagates_to_variants(
+        self,
+        async_client: AsyncClient,
+        db_session: AsyncSession,
+    ):
+        """ibs_max_threshold on the comparison request lands on every variant."""
+        request = {
+            **BASE_COMPARISON_REQUEST,
+            "ibs_max_threshold": 0.55,
+        }
+
+        response = await async_client.post("/api/v1/arena/comparisons", json=request)
+
+        assert response.status_code == 202
+        data = response.json()
+        assert len(data["simulations"]) >= 2
+        for sim in data["simulations"]:
+            assert sim["ibs_max_threshold"] == 0.55
+
+    @pytest.mark.asyncio
     async def test_create_comparison_with_agent_config_id_uses_config_algorithm(
         self,
         async_client: AsyncClient,

--- a/backend/tests/unit/services/arena/test_simulation_engine.py
+++ b/backend/tests/unit/services/arena/test_simulation_engine.py
@@ -5721,3 +5721,318 @@ class TestRiskBasedSizingClampedAndCappedByCash:
         assert pending.status == PositionStatus.OPEN.value
         # Capped at cash = $1000 → 10 shares (NOT 125 from the equity-based cap).
         assert pending.shares == 10
+
+
+@pytest.mark.usefixtures("db_session")
+class TestSimulationEngineIBSFilter:
+    """Tests for Internal Bar Strength (IBS) entry filter in step_day()."""
+
+    def _make_engine(self, db_session, rollback_session_factory) -> SimulationEngine:
+        return SimulationEngine(db_session, session_factory=rollback_session_factory)
+
+    def _make_bars(
+        self,
+        close: float,
+        high: float,
+        low: float,
+        n_history: int = 10,
+        target_date: date = date(2024, 1, 16),
+    ) -> list[PriceBar]:
+        """Build price bar history ending with a specific today bar."""
+        history = [
+            PriceBar(
+                date=date(2024, 1, 1) + timedelta(days=i),
+                open=Decimal("100.00"),
+                high=Decimal("105.00"),
+                low=Decimal("95.00"),
+                close=Decimal("100.00"),
+                volume=1_000_000,
+            )
+            for i in range(n_history)
+        ]
+        today = PriceBar(
+            date=target_date,
+            open=Decimal(str(close)),
+            high=Decimal(str(high)),
+            low=Decimal(str(low)),
+            close=Decimal(str(close)),
+            volume=1_000_000,
+        )
+        return history + [today]
+
+    async def _run_step_day(
+        self,
+        db_session,
+        rollback_session_factory,
+        ibs_max_threshold: float | None,
+        close: float,
+        high: float,
+        low: float,
+    ) -> tuple[int, dict]:
+        """Create a simulation with one symbol and run step_day, returning (pending_count, decisions)."""
+        sim = ArenaSimulation(
+            name="IBS Filter Test",
+            symbols=["AAPL"],
+            start_date=date(2024, 1, 15),
+            end_date=date(2024, 1, 20),
+            initial_capital=Decimal("10000.00"),
+            position_size=Decimal("1000.00"),
+            agent_type="live20",
+            agent_config={
+                "trailing_stop_pct": 5.0,
+                "ibs_max_threshold": ibs_max_threshold,
+            },
+            status=SimulationStatus.RUNNING.value,
+            current_day=0,
+            total_days=3,
+        )
+        db_session.add(sim)
+        await db_session.commit()
+        await db_session.refresh(sim)
+
+        engine = self._make_engine(db_session, rollback_session_factory)
+
+        trading_days = [date(2024, 1, 16), date(2024, 1, 17)]
+        bars = self._make_bars(close=close, high=high, low=low)
+
+        engine._trading_days_cache[sim.id] = trading_days
+        engine._price_cache[sim.id] = {"AAPL": bars}
+        engine._sector_cache[sim.id] = {"AAPL": None}
+
+        mock_agent = MagicMock()
+        mock_agent.required_lookback_days = 5
+        mock_agent.evaluate = AsyncMock(
+            return_value=AgentDecision(symbol="AAPL", action="BUY", score=80)
+        )
+
+        with patch("app.services.arena.simulation_engine.get_agent", return_value=mock_agent):
+            await engine.step_day(sim.id)
+
+        result = await db_session.execute(
+            select(ArenaPosition)
+            .where(ArenaPosition.simulation_id == sim.id)
+            .where(ArenaPosition.status == PositionStatus.PENDING.value)
+        )
+        pending = result.scalars().all()
+
+        # Retrieve decisions from the snapshot
+        snap_result = await db_session.execute(
+            select(ArenaSnapshot).where(ArenaSnapshot.simulation_id == sim.id)
+        )
+        snapshot = snap_result.scalar_one_or_none()
+        decisions = snapshot.decisions if snapshot else {}
+
+        return len(pending), decisions
+
+    # ------------------------------------------------------------------
+    # Core filter logic
+    # ------------------------------------------------------------------
+
+    @pytest.mark.unit
+    async def test_ibs_filter_blocks_entry_when_ibs_at_threshold(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """IBS >= threshold: BUY signal is filtered out, no PENDING position created."""
+        # IBS = (close-low)/(high-low) = (55-40)/(60-40) = 15/20 = 0.75 >= 0.55
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.55,
+            close=55.0, high=60.0, low=40.0,
+        )
+        assert pending_count == 0, "IBS >= threshold should block BUY signal"
+
+    @pytest.mark.unit
+    async def test_ibs_filter_allows_entry_when_ibs_below_threshold(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """IBS < threshold: BUY signal passes through, PENDING position created."""
+        # IBS = (42-40)/(60-40) = 2/20 = 0.10 < 0.55
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.55,
+            close=42.0, high=60.0, low=40.0,
+        )
+        assert pending_count == 1, "IBS < threshold should allow BUY signal"
+
+    @pytest.mark.unit
+    async def test_ibs_boundary_exactly_at_threshold_is_blocked(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """IBS == threshold is blocked (>= comparison)."""
+        # IBS = (51-40)/(60-40) = 11/20 = 0.55 exactly == threshold
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.55,
+            close=51.0, high=60.0, low=40.0,
+        )
+        assert pending_count == 0, "IBS == threshold should be blocked"
+
+    @pytest.mark.unit
+    async def test_ibs_boundary_one_epsilon_below_threshold_is_allowed(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """IBS just below threshold passes (strict less-than)."""
+        # IBS = (50.99-40)/(60-40) = 10.99/20 = 0.5495 < 0.55
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.55,
+            close=50.99, high=60.0, low=40.0,
+        )
+        assert pending_count == 1, "IBS just below threshold should pass"
+
+    @pytest.mark.unit
+    async def test_ibs_boundary_decimal_precision_at_threshold(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """Engineered close/high/low producing IBS exactly 0.5 is blocked when threshold=0.5."""
+        # IBS = (50-40)/(60-40) = 10/20 = 0.5 == threshold(0.5) → blocked
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.5,
+            close=50.0, high=60.0, low=40.0,
+        )
+        assert pending_count == 0, "IBS == 0.5 at threshold 0.5 should be blocked"
+
+    @pytest.mark.unit
+    async def test_ibs_zero_range_day_defaults_to_neutral_ibs_05(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """Zero-range day (high == low) defaults IBS to 0.5 (neutral)."""
+        # high == low == close → IBS defaults to 0.5
+        # threshold=0.6 → 0.5 < 0.6 → should ALLOW entry
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.6,
+            close=50.0, high=50.0, low=50.0,
+        )
+        assert pending_count == 1, "Zero-range day IBS=0.5 < threshold=0.6 should allow entry"
+
+    @pytest.mark.unit
+    async def test_ibs_zero_range_day_blocked_when_threshold_at_or_below_neutral(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """Zero-range day IBS=0.5 blocked when threshold <= 0.5."""
+        # IBS=0.5 == threshold=0.5 → blocked
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.5,
+            close=50.0, high=50.0, low=50.0,
+        )
+        assert pending_count == 0, "Zero-range day IBS=0.5 == threshold=0.5 should be blocked"
+
+    @pytest.mark.unit
+    async def test_ibs_filter_disabled_when_threshold_is_none(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """No filtering occurs when ibs_max_threshold is None."""
+        # Even with high IBS (close at top of range), no filter → PENDING created
+        pending_count, _ = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=None,
+            close=59.0, high=60.0, low=40.0,
+        )
+        assert pending_count == 1, "IBS filter disabled (None) should allow all BUY signals"
+
+    # ------------------------------------------------------------------
+    # Decisions dict annotations
+    # ------------------------------------------------------------------
+
+    @pytest.mark.unit
+    async def test_ibs_filtered_and_ibs_value_recorded_in_decisions(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """Filtered signals have ibs_filtered=True and ibs_value recorded in decisions."""
+        # IBS = (55-40)/(60-40) = 0.75 >= threshold=0.55 → filtered
+        _, decisions = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.55,
+            close=55.0, high=60.0, low=40.0,
+        )
+        aapl = decisions.get("AAPL", {})
+        assert aapl.get("ibs_filtered") is True, "ibs_filtered should be True for filtered signal"
+        assert aapl.get("ibs_value") == 0.75, f"ibs_value should be 0.75, got {aapl.get('ibs_value')}"
+
+    @pytest.mark.unit
+    async def test_portfolio_selected_false_set_for_filtered_signals(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """Filtered signals have portfolio_selected=False in decisions."""
+        # IBS = (55-40)/(60-40) = 0.75 >= threshold=0.55 → filtered
+        _, decisions = await self._run_step_day(
+            db_session, rollback_session_factory,
+            ibs_max_threshold=0.55,
+            close=55.0, high=60.0, low=40.0,
+        )
+        aapl = decisions.get("AAPL", {})
+        assert aapl.get("portfolio_selected") is False, "portfolio_selected should be False for filtered signal"
+
+    @pytest.mark.unit
+    async def test_ibs_filtered_symbol_excluded_from_portfolio_selection(
+        self, db_session, rollback_session_factory
+    ) -> None:
+        """IBS-filtered symbol is excluded from portfolio selection (buy_signals list is pruned)."""
+        # Use 2 symbols: AAPL has high IBS (filtered), MSFT has low IBS (passes)
+        sim = ArenaSimulation(
+            name="IBS Filter Portfolio Exclusion Test",
+            symbols=["AAPL", "MSFT"],
+            start_date=date(2024, 1, 15),
+            end_date=date(2024, 1, 20),
+            initial_capital=Decimal("10000.00"),
+            position_size=Decimal("1000.00"),
+            agent_type="live20",
+            agent_config={
+                "trailing_stop_pct": 5.0,
+                "ibs_max_threshold": 0.55,
+            },
+            status=SimulationStatus.RUNNING.value,
+            current_day=0,
+            total_days=3,
+        )
+        db_session.add(sim)
+        await db_session.commit()
+        await db_session.refresh(sim)
+
+        engine = self._make_engine(db_session, rollback_session_factory)
+        engine._trading_days_cache[sim.id] = [date(2024, 1, 16), date(2024, 1, 17)]
+
+        # AAPL: high IBS=0.75 → filtered; MSFT: low IBS=0.1 → passes
+        aapl_bars = self._make_bars(close=55.0, high=60.0, low=40.0)  # IBS=0.75
+        msft_bars = self._make_bars(close=42.0, high=60.0, low=40.0)  # IBS=0.10
+
+        engine._price_cache[sim.id] = {"AAPL": aapl_bars, "MSFT": msft_bars}
+        engine._sector_cache[sim.id] = {"AAPL": None, "MSFT": None}
+
+        mock_agent = MagicMock()
+        mock_agent.required_lookback_days = 5
+        mock_agent.evaluate = AsyncMock(
+            return_value=AgentDecision(symbol="AAPL", action="BUY", score=80)
+        )
+
+        with patch("app.services.arena.simulation_engine.get_agent", return_value=mock_agent):
+            await engine.step_day(sim.id)
+
+        result = await db_session.execute(
+            select(ArenaPosition)
+            .where(ArenaPosition.simulation_id == sim.id)
+            .where(ArenaPosition.status == PositionStatus.PENDING.value)
+        )
+        pending = result.scalars().all()
+        pending_symbols = {p.symbol for p in pending}
+
+        # Only MSFT should have a PENDING position; AAPL was IBS-filtered
+        assert "MSFT" in pending_symbols, "MSFT (low IBS) should pass through to portfolio selection"
+        assert "AAPL" not in pending_symbols, "AAPL (high IBS) should be excluded from portfolio selection"
+
+        # Check AAPL's decision annotations
+        snap_result = await db_session.execute(
+            select(ArenaSnapshot).where(ArenaSnapshot.simulation_id == sim.id)
+        )
+        snapshot = snap_result.scalar_one_or_none()
+        assert snapshot is not None
+        aapl_decision = snapshot.decisions.get("AAPL", {})
+        assert aapl_decision.get("ibs_filtered") is True
+        assert aapl_decision.get("portfolio_selected") is False
+
+        # MSFT should not have ibs_filtered set (it passed)
+        msft_decision = snapshot.decisions.get("MSFT", {})
+        assert "ibs_filtered" not in msft_decision

--- a/backend/tests/unit/services/arena/test_simulation_engine.py
+++ b/backend/tests/unit/services/arena/test_simulation_engine.py
@@ -5881,17 +5881,21 @@ class TestSimulationEngineIBSFilter:
         assert pending_count == 1, "IBS just below threshold should pass"
 
     @pytest.mark.unit
-    async def test_ibs_boundary_decimal_precision_at_threshold(
+    async def test_ibs_boundary_float_precision_rounding_blocks_entry(
         self, db_session, rollback_session_factory
     ) -> None:
-        """Engineered close/high/low producing IBS exactly 0.5 is blocked when threshold=0.5."""
-        # IBS = (50-40)/(60-40) = 10/20 = 0.5 == threshold(0.5) → blocked
+        """Float-cast IBS at the threshold blocks entry even when the underlying
+        Decimal division isn't exactly representable in IEEE-754."""
+        # Decimal(0.1)/Decimal(0.3) cast to float is 0.3333333333333333.
+        # Threshold literal 1/3 in Python float is also 0.3333333333333333.
+        # ibs >= threshold must still block — verifying the float rounding
+        # isn't introducing an off-by-one at the boundary.
         pending_count, _ = await self._run_step_day(
             db_session, rollback_session_factory,
-            ibs_max_threshold=0.5,
-            close=50.0, high=60.0, low=40.0,
+            ibs_max_threshold=1 / 3,
+            close=50.1, high=50.3, low=50.0,
         )
-        assert pending_count == 0, "IBS == 0.5 at threshold 0.5 should be blocked"
+        assert pending_count == 0, "IBS at float-rounded threshold should be blocked"
 
     @pytest.mark.unit
     async def test_ibs_zero_range_day_defaults_to_neutral_ibs_05(
@@ -6004,9 +6008,11 @@ class TestSimulationEngineIBSFilter:
 
         mock_agent = MagicMock()
         mock_agent.required_lookback_days = 5
-        mock_agent.evaluate = AsyncMock(
-            return_value=AgentDecision(symbol="AAPL", action="BUY", score=80)
-        )
+
+        async def _evaluate(symbol, *_args, **_kwargs):
+            return AgentDecision(symbol=symbol, action="BUY", score=80)
+
+        mock_agent.evaluate = AsyncMock(side_effect=_evaluate)
 
         with patch("app.services.arena.simulation_engine.get_agent", return_value=mock_agent):
             await engine.step_day(sim.id)

--- a/frontend/src/components/arena/ArenaConfigPanel.test.tsx
+++ b/frontend/src/components/arena/ArenaConfigPanel.test.tsx
@@ -78,6 +78,24 @@ describe('ArenaConfigPanel', () => {
     });
   });
 
+  describe('Entry Filters', () => {
+    it('renders IBS threshold row when ibs_max_threshold is set', () => {
+      render(<ArenaConfigPanel simulation={createMockSimulation({ ibs_max_threshold: 0.55 })} />);
+      expect(screen.getByText('IBS Threshold')).toBeInTheDocument();
+      expect(screen.getByText('0.55')).toBeInTheDocument();
+    });
+
+    it('does not render IBS threshold row when ibs_max_threshold is null', () => {
+      render(<ArenaConfigPanel simulation={createMockSimulation({ ibs_max_threshold: null })} />);
+      expect(screen.queryByText('IBS Threshold')).not.toBeInTheDocument();
+    });
+
+    it('does not render IBS threshold row when ibs_max_threshold is absent', () => {
+      render(<ArenaConfigPanel simulation={createMockSimulation()} />);
+      expect(screen.queryByText('IBS Threshold')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Symbol List', () => {
     it('renders symbol count', () => {
       render(<ArenaConfigPanel simulation={createMockSimulation()} />);

--- a/frontend/src/components/arena/ArenaConfigPanel.tsx
+++ b/frontend/src/components/arena/ArenaConfigPanel.tsx
@@ -250,7 +250,6 @@ export const ArenaConfigPanel = ({ simulation }: ArenaConfigPanelProps) => {
           </div>
         )}
 
-        {/* Entry Filters Row — only shown when IBS threshold is configured */}
         {simulation.ibs_max_threshold != null && (
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-4 pt-3 border-t border-border-subtle">
             <ConfigItem

--- a/frontend/src/components/arena/ArenaConfigPanel.tsx
+++ b/frontend/src/components/arena/ArenaConfigPanel.tsx
@@ -9,6 +9,7 @@ import {
   Calendar,
   ChevronDown,
   ChevronUp,
+  Filter,
   Layers,
   LayoutGrid,
   Settings2,
@@ -246,6 +247,19 @@ export const ArenaConfigPanel = ({ simulation }: ArenaConfigPanelProps) => {
                 />
               </>
             )}
+          </div>
+        )}
+
+        {/* Entry Filters Row — only shown when IBS threshold is configured */}
+        {simulation.ibs_max_threshold != null && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-4 pt-3 border-t border-border-subtle">
+            <ConfigItem
+              icon={<Filter className="h-3.5 w-3.5" />}
+              label="IBS Threshold"
+              value={
+                <span className="text-text-primary">{simulation.ibs_max_threshold}</span>
+              }
+            />
           </div>
         )}
 

--- a/frontend/src/components/arena/ArenaDecisionLog.test.tsx
+++ b/frontend/src/components/arena/ArenaDecisionLog.test.tsx
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ArenaDecisionLog } from './ArenaDecisionLog';
-import type { AgentDecision, Snapshot } from '../../types/arena';
+import type { DecisionEntry, Snapshot } from '../../types/arena';
 
-const mockDecisions: Record<string, AgentDecision> = {
+const mockDecisions: Record<string, DecisionEntry> = {
   AAPL: {
     action: 'BUY',
     score: 80,
@@ -231,5 +231,64 @@ describe('ArenaDecisionLog', () => {
     // Find the decision card (div with border and rounded-lg classes)
     const aaplCard = screen.getByText('AAPL').closest('.rounded-lg');
     expect(aaplCard).toHaveClass('border-accent-bullish/30');
+  });
+
+  it('should show IBS FILTERED badge when ibs_filtered is true', () => {
+    const mockOnSelect = vi.fn();
+    const ibsFilteredSnapshot: Snapshot = {
+      ...mockSnapshot,
+      decisions: {
+        AAPL: { action: 'BUY', score: 75, reasoning: null, ibs_filtered: true, ibs_value: 0.72 },
+      },
+    };
+    render(
+      <ArenaDecisionLog
+        snapshot={ibsFilteredSnapshot}
+        snapshots={[ibsFilteredSnapshot]}
+        onSelectSnapshot={mockOnSelect}
+      />
+    );
+
+    expect(screen.getByText('IBS FILTERED')).toBeInTheDocument();
+  });
+
+  it('should display ibs_value when present in decision entry', () => {
+    const mockOnSelect = vi.fn();
+    const ibsValueSnapshot: Snapshot = {
+      ...mockSnapshot,
+      decisions: {
+        NVDA: { action: 'BUY', score: 65, reasoning: null, ibs_filtered: true, ibs_value: 0.72 },
+      },
+    };
+    render(
+      <ArenaDecisionLog
+        snapshot={ibsValueSnapshot}
+        snapshots={[ibsValueSnapshot]}
+        onSelectSnapshot={mockOnSelect}
+      />
+    );
+
+    expect(screen.getByText('0.72')).toBeInTheDocument();
+    // The IBS value is rendered with a label prefix
+    expect(screen.getByText(/IBS:/)).toBeInTheDocument();
+  });
+
+  it('should not show IBS FILTERED badge when ibs_filtered is absent', () => {
+    const mockOnSelect = vi.fn();
+    const normalSnapshot: Snapshot = {
+      ...mockSnapshot,
+      decisions: {
+        AAPL: { action: 'BUY', score: 80, reasoning: 'Buy signal' },
+      },
+    };
+    render(
+      <ArenaDecisionLog
+        snapshot={normalSnapshot}
+        snapshots={[normalSnapshot]}
+        onSelectSnapshot={mockOnSelect}
+      />
+    );
+
+    expect(screen.queryByText('IBS FILTERED')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/arena/ArenaDecisionLog.tsx
+++ b/frontend/src/components/arena/ArenaDecisionLog.tsx
@@ -118,13 +118,25 @@ export const ArenaDecisionLog = ({
               >
                 <div className="flex items-center justify-between mb-1">
                   <Badge variant="outline">{symbol}</Badge>
-                  <Badge className={getActionBadgeClass(decision.action)}>
-                    {decision.action}
-                  </Badge>
+                  <div className="flex items-center gap-1.5">
+                    {decision.ibs_filtered && (
+                      <Badge className="bg-amber-500/15 text-amber-600 border border-amber-500/30 text-[10px]">
+                        IBS FILTERED
+                      </Badge>
+                    )}
+                    <Badge className={getActionBadgeClass(decision.action)}>
+                      {decision.action}
+                    </Badge>
+                  </div>
                 </div>
                 {decision.score !== null && (
                   <p className="text-sm">
                     Score: <span className="font-mono font-medium">{decision.score}/100</span>
+                  </p>
+                )}
+                {decision.ibs_value !== undefined && (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    IBS: <span className="font-mono">{decision.ibs_value}</span>
                   </p>
                 )}
                 {decision.reasoning && (

--- a/frontend/src/components/arena/ArenaSetupForm.test.tsx
+++ b/frontend/src/components/arena/ArenaSetupForm.test.tsx
@@ -839,6 +839,21 @@ describe('ArenaSetupForm', () => {
       );
     });
 
+    it('IBS value included in comparison payload when 2+ strategies selected', async () => {
+      const user = await renderWithPortfolioAndEntryFilters();
+      // Select a second strategy so the form routes through onSubmitComparison.
+      await user.click(screen.getByRole('button', { name: /best score — calm/i }));
+      const ibsInput = screen.getByLabelText(/ibs threshold/i);
+      fireEvent.change(ibsInput, { target: { value: '0.55' } });
+      await user.click(
+        screen.getByRole('button', { name: /start comparison \(2 strategies\)/i })
+      );
+      expect(mockOnSubmitComparison).toHaveBeenCalledWith(
+        expect.objectContaining({ ibs_max_threshold: 0.55 })
+      );
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
     it('IBS=0 shows inline error and form does not submit', async () => {
       await renderWithPortfolioAndEntryFilters();
       const ibsInput = screen.getByLabelText(/ibs threshold/i);

--- a/frontend/src/components/arena/ArenaSetupForm.test.tsx
+++ b/frontend/src/components/arena/ArenaSetupForm.test.tsx
@@ -786,6 +786,93 @@ describe('ArenaSetupForm', () => {
     });
   });
 
+  describe('IBS Entry Filter', () => {
+    /**
+     * Helper: render with valid symbols/dates and navigate to the Portfolio tab,
+     * then open the Entry Filters collapsible to expose the IBS input.
+     */
+    const renderWithPortfolioAndEntryFilters = async () => {
+      const user = userEvent.setup();
+      render(
+        <ArenaSetupForm
+          onSubmit={mockOnSubmit}
+          onSubmitComparison={mockOnSubmitComparison}
+          isLoading={false}
+        />
+      );
+      fireEvent.change(screen.getByRole('textbox', { name: /symbols/i }), {
+        target: { value: 'AAPL' },
+      });
+      fireEvent.change(screen.getByLabelText(/start date/i), {
+        target: { value: '2024-01-01' },
+      });
+      fireEvent.change(screen.getByLabelText(/end date/i), {
+        target: { value: '2024-06-01' },
+      });
+      await user.click(screen.getByRole('tab', { name: /portfolio/i }));
+      // Open the Entry Filters collapsible
+      await user.click(screen.getByRole('button', { name: /entry filters/i }));
+      return user;
+    };
+
+    it('IBS field renders inside Entry Filters collapsible in Portfolio tab', async () => {
+      await renderWithPortfolioAndEntryFilters();
+      expect(screen.getByLabelText(/ibs threshold/i)).toBeInTheDocument();
+    });
+
+    it('IBS omitted from payload when input is empty', async () => {
+      const user = await renderWithPortfolioAndEntryFilters();
+      // IBS field is empty (default) — submit
+      await user.click(screen.getByRole('button', { name: /start simulation/i }));
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.not.objectContaining({ ibs_max_threshold: expect.anything() })
+      );
+    });
+
+    it('IBS value > 0 included in payload', async () => {
+      const user = await renderWithPortfolioAndEntryFilters();
+      const ibsInput = screen.getByLabelText(/ibs threshold/i);
+      fireEvent.change(ibsInput, { target: { value: '0.55' } });
+      await user.click(screen.getByRole('button', { name: /start simulation/i }));
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ ibs_max_threshold: 0.55 })
+      );
+    });
+
+    it('IBS=0 shows inline error and form does not submit', async () => {
+      await renderWithPortfolioAndEntryFilters();
+      const ibsInput = screen.getByLabelText(/ibs threshold/i);
+      fireEvent.change(ibsInput, { target: { value: '0' } });
+      expect(screen.getByText(/must be greater than 0 and at most 1/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /start simulation/i })).toBeDisabled();
+    });
+
+    it('replay: initialValues.ibs_max_threshold pre-populates IBS field', async () => {
+      const user = userEvent.setup();
+      render(
+        <ArenaSetupForm
+          onSubmit={mockOnSubmit}
+          onSubmitComparison={mockOnSubmitComparison}
+          isLoading={false}
+          initialValues={{
+            symbols: ['AAPL'],
+            start_date: '2024-01-01',
+            end_date: '2024-06-01',
+            initial_capital: 10000,
+            position_size: 1000,
+            trailing_stop_pct: 5,
+            min_buy_score: 60,
+            ibs_max_threshold: 0.55,
+          }}
+        />
+      );
+      await user.click(screen.getByRole('tab', { name: /portfolio/i }));
+      await user.click(screen.getByRole('button', { name: /entry filters/i }));
+      const ibsInput = screen.getByLabelText(/ibs threshold/i) as HTMLInputElement;
+      expect(ibsInput.value).toBe('0.55');
+    });
+  });
+
   describe('initialValues (replay feature)', () => {
     it('should populate form fields from initialValues', async () => {
       const user = userEvent.setup();

--- a/frontend/src/components/arena/ArenaSetupForm.tsx
+++ b/frontend/src/components/arena/ArenaSetupForm.tsx
@@ -56,6 +56,7 @@ interface ArenaSetupFormProps {
     risk_per_trade_pct?: number | null;
     win_streak_bonus_pct?: number | null;
     max_risk_pct?: number | null;
+    ibs_max_threshold?: number | null;
   };
 }
 
@@ -157,6 +158,7 @@ export const ArenaSetupForm = ({
   const [maxOpenPositions, setMaxOpenPositions] = useState('');
   const [maSweetSpotCenter, setMaSweetSpotCenter] = useState('8.5');
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [entryFiltersOpen, setEntryFiltersOpen] = useState(false);
   // Stop type and ATR parameters
   const [stopType, setStopType] = useState<'fixed' | 'atr'>('fixed');
   const [atrStopMultiplier, setAtrStopMultiplier] = useState('2.0');
@@ -168,6 +170,8 @@ export const ArenaSetupForm = ({
   const [riskPerTradePct, setRiskPerTradePct] = useState('2.5');
   const [winStreakBonusPct, setWinStreakBonusPct] = useState('0.3');
   const [maxRiskPct, setMaxRiskPct] = useState('4.0');
+  // Entry filters
+  const [ibsMaxThreshold, setIbsMaxThreshold] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   /** Tracks whether ATR stop was auto-set by switching to risk_based sizing */
   const atrAutoSetByRiskSizing = useRef(false);
@@ -241,6 +245,9 @@ export const ArenaSetupForm = ({
       }
       if (initialValues.max_risk_pct != null) {
         setMaxRiskPct(initialValues.max_risk_pct.toString());
+      }
+      if (initialValues.ibs_max_threshold != null) {
+        setIbsMaxThreshold(initialValues.ibs_max_threshold.toString());
       }
       // Focus textarea after population
       setTimeout(() => textareaRef.current?.focus(), 0);
@@ -339,6 +346,14 @@ export const ArenaSetupForm = ({
     const positionSizeField =
       sizingMode === 'fixed' ? { position_size: parseFloat(positionSize) } : {};
 
+    // IBS entry filter — only sent when value is explicitly in (0, 1].
+    // Empty string = omit entirely (disabled). Value of 0 is blocked by hasIbsError.
+    const ibsParsedSubmit = ibsMaxThreshold === '' ? null : parseFloat(ibsMaxThreshold);
+    const entryFilterFields: Partial<CreateSimulationRequest> = {};
+    if (ibsParsedSubmit !== null && ibsParsedSubmit > 0 && ibsParsedSubmit <= 1) {
+      entryFilterFields.ibs_max_threshold = ibsParsedSubmit;
+    }
+
     if (selectedStrategies.length >= 2) {
       await onSubmitComparison({
         symbols: symbolList,
@@ -357,6 +372,7 @@ export const ArenaSetupForm = ({
         max_per_sector: parsedMaxPerSector,
         max_open_positions: parsedMaxOpenPositions,
         ...sizingFields,
+        ...entryFilterFields,
       });
     } else {
       await onSubmit({
@@ -377,6 +393,7 @@ export const ArenaSetupForm = ({
         max_open_positions: parsedMaxOpenPositions,
         ma_sweet_spot_center: parsedMaSweetSpotCenter,
         ...sizingFields,
+        ...entryFilterFields,
       });
     }
   }, [
@@ -402,6 +419,7 @@ export const ArenaSetupForm = ({
     riskPerTradePct,
     winStreakBonusPct,
     maxRiskPct,
+    ibsMaxThreshold,
     onSubmit,
     onSubmitComparison,
   ]);
@@ -423,6 +441,10 @@ export const ArenaSetupForm = ({
   const isAtrStop = stopType === 'atr';
   const isFixedPctSizing = sizingMode === 'fixed_pct';
   const isRiskBasedSizing = sizingMode === 'risk_based';
+
+  // IBS entry filter validation
+  const ibsParsed = ibsMaxThreshold === '' ? null : parseFloat(ibsMaxThreshold);
+  const hasIbsError = ibsParsed !== null && !(ibsParsed > 0 && ibsParsed <= 1);
 
   const hasValidPositionSize =
     isRiskBasedSizing || isFixedPctSizing || parseFloat(positionSize) > 0;
@@ -447,6 +469,7 @@ export const ArenaSetupForm = ({
     hasValidTrailingStop &&
     hasValidMinBuyScore &&
     hasStrategySelected &&
+    !hasIbsError &&
     !isLoading;
 
   let submitButtonLabel = 'Start Simulation';
@@ -1020,6 +1043,52 @@ export const ArenaSetupForm = ({
                 )}
               </div>
             )}
+
+            {/* Entry Filters — collapsible, always shown (applies to all strategies) */}
+            <div className="border-t border-border pt-4">
+              <button
+                type="button"
+                onClick={() => setEntryFiltersOpen((prev) => !prev)}
+                className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors duration-150 py-1"
+                aria-expanded={entryFiltersOpen}
+              >
+                <ChevronRight
+                  className={cn(
+                    'h-3.5 w-3.5 transition-transform duration-200',
+                    entryFiltersOpen && 'rotate-90',
+                  )}
+                />
+                Entry Filters
+              </button>
+
+              {entryFiltersOpen && (
+                <div className="pt-3 grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="arena-ibs-threshold">IBS Threshold</Label>
+                    <Input
+                      id="arena-ibs-threshold"
+                      type="number"
+                      min="0.01"
+                      max="1"
+                      step="0.05"
+                      placeholder="Disabled"
+                      value={ibsMaxThreshold}
+                      onChange={(e) => setIbsMaxThreshold(e.target.value)}
+                      className="mt-1"
+                      disabled={isLoading}
+                    />
+                    {hasIbsError && (
+                      <p className="text-xs text-destructive">
+                        Must be greater than 0 and at most 1
+                      </p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Filter entries when close is near daily high. Typical: 0.55. Empty = disabled.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
           </TabsContent>
         </Tabs>
 

--- a/frontend/src/components/arena/ArenaSetupForm.tsx
+++ b/frontend/src/components/arena/ArenaSetupForm.tsx
@@ -346,13 +346,14 @@ export const ArenaSetupForm = ({
     const positionSizeField =
       sizingMode === 'fixed' ? { position_size: parseFloat(positionSize) } : {};
 
-    // IBS entry filter — only sent when value is explicitly in (0, 1].
-    // Empty string = omit entirely (disabled). Value of 0 is blocked by hasIbsError.
-    const ibsParsedSubmit = ibsMaxThreshold === '' ? null : parseFloat(ibsMaxThreshold);
-    const entryFilterFields: Partial<CreateSimulationRequest> = {};
-    if (ibsParsedSubmit !== null && ibsParsedSubmit > 0 && ibsParsedSubmit <= 1) {
-      entryFilterFields.ibs_max_threshold = ibsParsedSubmit;
-    }
+    // IBS entry filter: empty input = omit (disabled). Defense-in-depth range
+    // check here in case handleSubmit is ever reached with a stale/invalid value
+    // (hasIbsError/canSubmit already gates the button path).
+    const ibsSubmit = ibsMaxThreshold === '' ? null : parseFloat(ibsMaxThreshold);
+    const entryFilterFields: Partial<CreateSimulationRequest> =
+      ibsSubmit !== null && ibsSubmit > 0 && ibsSubmit <= 1
+        ? { ibs_max_threshold: ibsSubmit }
+        : {};
 
     if (selectedStrategies.length >= 2) {
       await onSubmitComparison({
@@ -1044,13 +1045,13 @@ export const ArenaSetupForm = ({
               </div>
             )}
 
-            {/* Entry Filters — collapsible, always shown (applies to all strategies) */}
             <div className="border-t border-border pt-4">
               <button
                 type="button"
                 onClick={() => setEntryFiltersOpen((prev) => !prev)}
                 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors duration-150 py-1"
                 aria-expanded={entryFiltersOpen}
+                aria-controls="arena-entry-filters-panel"
               >
                 <ChevronRight
                   className={cn(
@@ -1062,7 +1063,7 @@ export const ArenaSetupForm = ({
               </button>
 
               {entryFiltersOpen && (
-                <div className="pt-3 grid grid-cols-2 gap-4">
+                <div id="arena-entry-filters-panel" className="pt-3 grid grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="arena-ibs-threshold">IBS Threshold</Label>
                     <Input

--- a/frontend/src/types/arena.ts
+++ b/frontend/src/types/arena.ts
@@ -118,13 +118,9 @@ export interface AgentDecision {
   reasoning: string | null;
 }
 
-/** Snapshot decision entry: agent output + engine filter annotations */
-export interface DecisionEntry {
-  // Agent output (same fields as AgentDecision)
-  action: string;
-  score: number | null;
-  reasoning: string | null;
-  // Engine annotations (added by portfolio execution / entry filters)
+/** Snapshot decision entry: agent output plus engine-added annotations from
+ * portfolio selection and entry filters. */
+export interface DecisionEntry extends AgentDecision {
   portfolio_selected?: boolean;
   ibs_filtered?: boolean;
   ibs_value?: number;

--- a/frontend/src/types/arena.ts
+++ b/frontend/src/types/arena.ts
@@ -64,6 +64,7 @@ export interface Simulation {
   risk_per_trade_pct?: number | null;
   win_streak_bonus_pct?: number | null;
   max_risk_pct?: number | null;
+  ibs_max_threshold?: number | null;
   group_id: string | null;
   status: SimulationStatus;
   current_day: number;
@@ -117,6 +118,18 @@ export interface AgentDecision {
   reasoning: string | null;
 }
 
+/** Snapshot decision entry: agent output + engine filter annotations */
+export interface DecisionEntry {
+  // Agent output (same fields as AgentDecision)
+  action: string;
+  score: number | null;
+  reasoning: string | null;
+  // Engine annotations (added by portfolio execution / entry filters)
+  portfolio_selected?: boolean;
+  ibs_filtered?: boolean;
+  ibs_value?: number;
+}
+
 /** Daily snapshot of portfolio state */
 export interface Snapshot {
   id: number;
@@ -130,7 +143,7 @@ export interface Snapshot {
   cumulative_return_pct: string;
   open_position_count: number;
   /** Agent decisions keyed by symbol */
-  decisions: Record<string, AgentDecision>;
+  decisions: Record<string, DecisionEntry>;
 }
 
 /** Full simulation detail with positions and snapshots */
@@ -194,6 +207,8 @@ export interface CreateSimulationRequest {
   win_streak_bonus_pct?: number;
   /** Maximum effective risk % per trade cap (used when sizing_mode='risk_based') */
   max_risk_pct?: number;
+  /** IBS max threshold for entry filter (0, 1]; omit or null = disabled */
+  ibs_max_threshold?: number;
 }
 
 /** Response from step endpoint */
@@ -246,6 +261,8 @@ export interface CreateComparisonRequest {
   win_streak_bonus_pct?: number;
   /** Maximum effective risk % per trade cap (used when sizing_mode='risk_based') */
   max_risk_pct?: number;
+  /** IBS max threshold for entry filter (0, 1]; omit or null = disabled */
+  ibs_max_threshold?: number;
 }
 
 /** Response from comparison creation / retrieval */

--- a/thoughts/shared/plans/phase-4-ibs-entry-filter.md
+++ b/thoughts/shared/plans/phase-4-ibs-entry-filter.md
@@ -1,0 +1,231 @@
+# Phase 4: IBS Entry Filter (#51)
+
+Parent: #47 -- ATR-Based Exit Strategies
+Depends on: None (independent of other phases)
+
+## Status
+
+Implemented.
+
+## What
+
+Add Internal Bar Strength (IBS) as an entry filter. IBS measures where a stock's close falls within its daily range. Low IBS (close near the low) suggests oversold conditions favorable for mean-reversion entry. High IBS (close near the high) suggests the stock has already bounced -- less favorable.
+
+## Why
+
+The conservative strategy uses IBS < 0.55 to filter entries. This reduces entries on days when the stock has already moved up within its range, lowering drawdown at the cost of fewer trades.
+
+---
+
+## Backend Changes
+
+### 4a. IBS Calculation
+
+IBS = `(close - low) / (high - low)`. One-liner, no separate utility needed.
+
+Edge case: if `high == low` (zero range day), IBS defaults to 0.5 (neutral).
+
+### 4b. Where to Apply
+
+**In simulation_engine.py, not in the agent.** The agent generates signals (BUY/NO_SIGNAL). Entry filters gate whether a signal is acted upon. This matches existing patterns (regime filter, portfolio selector operate in the engine downstream of agent decisions).
+
+Location: `simulation_engine.py` -- after BUY signal collection (line 718) and before portfolio selection (line 720). Add a filter pass:
+
+```python
+# --- Entry Filters ---
+# Entry filters run AFTER agent evaluation populates decisions[symbol]
+# (simulation_engine.py:710-714) and BUY signal collection (line 716-718),
+# but BEFORE portfolio selection (line 720+).
+#
+# decisions[symbol] is fully populated by agent evaluation loop above.
+# today_bar is non-None guaranteed here: BUY signals only generated
+# after today_bar check at simulation_engine.py line 419.
+# The `today_bar is None` fallback is dead code kept as a safety net.
+
+ibs_max = simulation.agent_config.get("ibs_max_threshold")
+if ibs_max is not None:
+    filtered_buy_signals = []
+    for symbol, decision in buy_signals:
+        today_bar = self._get_cached_bar_for_date(simulation_id, symbol, current_date)
+        if today_bar and today_bar.high != today_bar.low:
+            ibs = float((today_bar.close - today_bar.low) / (today_bar.high - today_bar.low))
+        else:
+            # high == low (zero-range day): use neutral IBS.
+            # today_bar is non-None here by construction -- BUY signals are only
+            # collected after the today_bar guard at simulation_engine.py:419.
+            ibs = 0.5
+        if ibs < ibs_max:
+            filtered_buy_signals.append((symbol, decision))
+        else:
+            decisions[symbol]["ibs_filtered"] = True
+            decisions[symbol]["ibs_value"] = round(ibs, 4)
+            decisions[symbol]["portfolio_selected"] = False
+    buy_signals = filtered_buy_signals
+```
+
+### 4c. Schema Changes
+
+New field on `CreateSimulationRequest` (`schemas/arena.py:59`) AND `CreateComparisonRequest` (`schemas/arena.py:353`):
+- `ibs_max_threshold: float | None = None` (**gt=0, le=1**). None = disabled.
+
+**Critical: `gt=0` not `ge=0`.** Since IBS = (close-low)/(high-low) is mathematically bounded to [0,1], `ibs < 0` is never true. If the schema accepted `0`, the comparison `if ibs < 0` would filter every BUY signal, producing a simulation with zero trades that looks valid. Direct API calls (scripts, tests, replay endpoints) bypass frontend validation, so the backend must reject `0` itself. Precedent: `trailing_stop_pct` uses `gt=0` at `schemas/arena.py:103` for similar safety reasons.
+
+Single field design: None = off, set value ∈ (0, 1] = active. No separate boolean toggle needed.
+
+### 4d. API Wiring (5-Step Process)
+
+1. **Schema fields**: Add `ibs_max_threshold` to `CreateSimulationRequest` (`schemas/arena.py:59`) and `CreateComparisonRequest` (`schemas/arena.py:353`)
+2. **agent_config in create_simulation()**: Add to agent_config dict (`arena.py:256-297`):
+   ```python
+   # Layer 10: Entry filters
+   "ibs_max_threshold": request.ibs_max_threshold,
+   ```
+3. **agent_config in create_comparison()**: Add to `base_agent_config` dict (`arena.py:698-716`):
+   ```python
+   "ibs_max_threshold": request.ibs_max_threshold,
+   ```
+   This ensures comparison simulations support IBS identically to single simulations.
+4. **_build_simulation_response()** (`arena.py:78-155`): Extract and return the field:
+   ```python
+   ibs_max_threshold = agent_config.get("ibs_max_threshold")
+   ```
+   Add to `SimulationResponse` (`schemas/arena.py:631`):
+   ```python
+   ibs_max_threshold: float | None = None
+   ```
+   Add to the `SimulationResponse(...)` constructor call (`arena.py:109-155`):
+   ```python
+   ibs_max_threshold=ibs_max_threshold,
+   ```
+5. **step_day()**: Read from `simulation.agent_config` in the entry filter block (see 4b above)
+
+### 4e. No DB Migration
+
+All config stored in `agent_config` JSON. No model changes needed.
+
+---
+
+## Frontend Changes
+
+The form is split into 3 tabs: **Setup** (symbols, dates, capital), **Agent** (agent type, scoring), **Portfolio** (strategy, constraints, tuning). Entry filters belong in the **Portfolio** tab under a collapsible "Entry Filters" section (similar to the existing "Advanced Tuning" collapsible). Label the section generically as "Entry Filters" since Phase 5 will add MA50 and circuit breaker controls to the same section.
+
+### F1. TypeScript types (`types/arena.ts`)
+
+Add `ibs_max_threshold` to:
+- `Simulation` interface (`types/arena.ts:36-83`):
+  ```typescript
+  ibs_max_threshold?: number | null;
+  ```
+- `CreateSimulationRequest` interface (`types/arena.ts:144-197`):
+  ```typescript
+  ibs_max_threshold?: number;
+  ```
+- `CreateComparisonRequest` interface (`types/arena.ts:214-249`):
+  ```typescript
+  ibs_max_threshold?: number;
+  ```
+
+**New `DecisionEntry` type**: Do NOT extend `AgentDecision`. `AgentDecision` (`types/arena.ts:114-118`) represents pure agent output (action, score, reasoning) and is used elsewhere. Create a new `DecisionEntry` interface for the annotated snapshot decisions:
+
+```typescript
+/** Snapshot decision entry: agent output + engine filter annotations */
+export interface DecisionEntry {
+  // Agent output (same fields as AgentDecision)
+  action: string;
+  score: number | null;
+  reasoning: string | null;
+  // Engine annotations (added by portfolio execution / entry filters)
+  portfolio_selected?: boolean;
+  ibs_filtered?: boolean;
+  ibs_value?: number;
+}
+```
+
+Update `Snapshot.decisions` type (`types/arena.ts:133`):
+```typescript
+decisions: Record<string, DecisionEntry>;  // was Record<string, AgentDecision>
+```
+
+`ArenaDecisionLog` already uses `Object.entries(snapshot.decisions)` -- this is a type-level change, non-breaking at runtime. Update `ArenaDecisionLog.test.tsx` mock type from `Record<string, AgentDecision>` to `Record<string, DecisionEntry>` to match.
+
+### F2. ArenaSetupForm -- Portfolio tab (`ArenaSetupForm.tsx`)
+
+Add a collapsible "Entry Filters" section below the constraints grid. Include an IBS threshold input (number, 0-1 range, placeholder "Disabled"). This section will also hold MA50 and circuit breaker controls in Phase 5.
+
+**IBS field validation** (CRITICAL -- JavaScript truthy bug): The naive check `ibsValue ? parseFloat(ibsValue) : undefined` treats `'0'` as truthy, which would send `ibs_max_threshold=0` -- blocking ALL entries since IBS is never < 0. The plan must specify:
+- IBS field is active only when `value > 0 && value <= 1`
+- A value of `0` must show an inline error ("Must be greater than 0") or be treated as disabled
+- Empty field = omit `ibs_max_threshold` from request body entirely (not sent as `''` or `0`)
+- Add IBS validation to the `canSubmit` guard
+
+Add `ibs_max_threshold` to the `initialValues` prop type (`ArenaSetupForm.tsx:36-58`):
+```typescript
+initialValues?: {
+  // ... existing fields ...
+  ibs_max_threshold?: number | null;
+};
+```
+Without this, replaying a simulation loses IBS config. On a real-money system, this is silent data loss -- the user reruns thinking it's the same strategy but results diverge.
+
+### F3. ArenaConfigPanel
+
+Display IBS threshold when configured.
+
+### F4. ArenaDecisionLog
+
+Display `ibs_filtered` badge and `ibs_value` when present in decisions.
+
+---
+
+## Testing
+
+### Backend Tests
+
+| Test File | What to Test |
+|-----------|-------------|
+| test_simulation_engine.py | IBS filter blocks entry when IBS >= threshold |
+| test_simulation_engine.py | IBS filter allows entry when IBS < threshold |
+| test_simulation_engine.py | **Boundary value**: `ibs == threshold` is blocked (>= comparison) |
+| test_simulation_engine.py | **Boundary value**: `ibs == threshold - epsilon` is allowed |
+| test_simulation_engine.py | **Boundary value**: Decimal precision at threshold (engineered close/high/low producing IBS exactly at boundary) |
+| test_simulation_engine.py | Zero-range day (high == low) defaults to IBS 0.5 |
+| test_simulation_engine.py | IBS filter disabled when threshold is None |
+| test_simulation_engine.py | `ibs_filtered` and `ibs_value` recorded in decisions dict |
+| test_simulation_engine.py | `portfolio_selected = False` set for filtered signals |
+| test_simulation_engine.py | IBS-filtered symbol excluded from portfolio selection: not in `buy_signals` passed to `get_selector().select()`, `portfolio_selected` not overwritten to True |
+| test_arena_api.py | POST with `ibs_max_threshold=0.55` accepted; GET returns it in response |
+| test_arena_api.py | POST with `ibs_max_threshold=0` rejected with 422 (backend-level protection against the silent all-trades-off config; must pass without the frontend in the loop) |
+| test_arena_api.py | POST with `ibs_max_threshold=-0.01` rejected with 422 |
+| test_arena_api.py | POST with `ibs_max_threshold=1.0` accepted (upper bound inclusive) |
+
+### Frontend Tests
+
+| Scenario | Component | What to Test |
+|----------|-----------|-------------|
+| Renders in Portfolio tab | ArenaSetupForm | IBS threshold field renders inside "Entry Filters" collapsible |
+| Included in payload | ArenaSetupForm | IBS value > 0 included in submit payload |
+| Omitted when empty | ArenaSetupForm | IBS omitted from payload when field is empty |
+| IBS=0 shows error | ArenaSetupForm | Value of 0 shows inline error, form does not submit |
+| Decision log badge | ArenaDecisionLog | Shows `ibs_filtered` badge when present in snapshot decision |
+| Decision log IBS value | ArenaDecisionLog | Shows `ibs_value` when present in decision entry |
+| Config panel display | ArenaConfigPanel | Renders IBS threshold row when configured |
+| Replay populates IBS | ArenaSetupForm | `initialValues` with `ibs_max_threshold` pre-populates IBS field |
+| Mock type consistency | ArenaDecisionLog.test | Mock uses `Record<string, DecisionEntry>` (not `AgentDecision`) |
+
+### Pre-Phase Test Audit
+
+Grepping for full-dict equality assertions (`assert decisions[symbol] == {...}`) found NONE in the current test suite. Existing tests use key-specific assertions (e.g., `test_simulation_engine.py:2724-2725`, `test_simulation_engine.py:2899-2903`). Adding `ibs_filtered`, `ibs_value`, `portfolio_selected` keys to the decisions dict will not break existing tests. Confirm this finding before implementation.
+
+## Success Criteria
+
+- [x] Simulations with `ibs_max_threshold=0.55` reject entries where close is near daily high
+- [x] Boundary: `ibs == threshold` is rejected; `ibs == threshold - epsilon` is accepted
+- [x] Filter decisions recorded in snapshot for transparency
+- [x] Disabled by default (None) -- no impact on existing simulations
+- [x] Zero-range edge case handled gracefully
+- [x] Comparison simulations support IBS filter identically to single simulations
+- [x] Replaying a simulation preserves IBS config via initialValues
+- [x] IBS=0 treated as disabled (inline error), not sent to backend
+- [x] Backend schema rejects `ibs_max_threshold=0` with 422 (defense in depth -- API clients cannot bypass the frontend guard)
+- [x] `DecisionEntry` type used for snapshot decisions; `AgentDecision` unchanged
+- [x] IBS-filtered symbol excluded from portfolio selection (not in `buy_signals` passed to selector)


### PR DESCRIPTION
## Summary
- Adds an Internal Bar Strength (IBS) entry filter that prunes BUY signals where `IBS = (close - low) / (high - low) >= threshold` before portfolio selection, avoiding entries near the daily high.
- Wires `ibs_max_threshold` through the canonical `agent_config` path (schema → API → engine → response → UI) on both `/simulations` and `/comparisons` endpoints.
- UI surfaces the filter in a new Entry Filters collapsible in the Portfolio tab, shows the configured threshold on the simulation detail panel, and renders an "IBS FILTERED" badge plus IBS value in the decision log.

## Feature Intent
Closes #51 (Phase 4: IBS Entry Filter). Mean-reversion agents should not open long positions in stocks that have already run up to their daily high — IBS is the standard metric for this and is tunable per simulation (`None` = disabled; valid range is `(0, 1]`).

## Implementation Notes
- Schema constraint `gt=0, le=1` prevents the silent "zero trades" misconfig; strict `<` comparator (`ibs < ibs_max`) means threshold-value and above filter the signal.
- Zero-range days (`high == low`) default to neutral `IBS = 0.5`.
- Engine `buy_signals` tuple carries `today_bar` so the Layer 10 filter reuses the already-fetched bar instead of re-scanning the price cache.
- Frontend `handleSubmit` has a defense-in-depth range check even though `canSubmit`/`hasIbsError` gate the button path — this system handles real money.
- New `DecisionEntry` type extends `AgentDecision` with engine-added annotations (`ibs_filtered`, `ibs_value`, `portfolio_selected`), keeping the pure-agent contract intact for other call sites.

## Review History
Ran full `/code-review-by-team` (6 reviewers: backend, frontend, QA, security, devil's advocate, feature alignment). No security issues, no correctness bugs. Fix-now items landed in the review-feedback commit:
- Threaded `today_bar` through `buy_signals` to drop redundant bar lookup
- Defense-in-depth IBS range guard in `handleSubmit`
- `aria-controls` on the Entry Filters collapsible
- Comparison endpoint IBS propagation test + comparison submit-path form test
- Per-symbol mock in multi-symbol exclusion test
- Renamed misleading float-precision boundary test to exercise real IEEE-754 rounding

## Test Plan
- [x] Backend unit — `TestSimulationEngineIBSFilter` 11/11 pass
- [x] Backend API — new `test_create_comparison_with_ibs_max_threshold_propagates_to_variants` + 4 schema boundary tests (0, -0.01, 0.55, 1.0)
- [x] Frontend — 81/81 arena tests pass (includes comparison-path IBS submit)
- [x] TypeScript — `tsc --noEmit` clean
- [ ] Manual QA: run an IBS-enabled simulation on a 2025 dataset and verify decision log shows "IBS FILTERED" badges for skipped signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)